### PR TITLE
Capitalization for language names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Goodreads Part I: CSV Files
 
-We will use three main programming languages in this class: python, shell, and sql.
+We will use three main programming languages in this class: Python, Shell, and SQL.
 In this first part of the lab we will do some basic data exploration with each of these languages.
 
 We will use data on user "interactions" from the <https://goodreads.com> website,


### PR DESCRIPTION
Originally, "python, shell, and sql" but it should be "Python, Shell, and SQL" because Python is a proper noun (the language name), SQL is an acronym (Structured Query Language) thus should be in all caps, and  Shell is capitalized when referring to the concept/language. 